### PR TITLE
Fix ADB Shell detection

### DIFF
--- a/common/mod-util.sh
+++ b/common/mod-util.sh
@@ -100,7 +100,7 @@ N='\e[0m'			# How to use (example): echo "${G}example${N}"
 loadBar=' '			# Load UI
 # Remove color codes if -nc or in ADB Shell
 [ -n "$1" -a "$1" == "-nc" ] && shift && NC=true
-[ "$NC" -o -n "$LOGNAME" ] && {
+[ "$NC" -o -n "$ADB_TRACE" ] && {
 	G=''; R=''; Y=''; B=''; V=''; Bl=''; C=''; W=''; N=''; BGBL=''; loadBar='=';
 }
 


### PR DESCRIPTION
Currently LOGNAME is checked, which exists in environment of all login shells, and is not related to ADB shell. To correctly detect ADB shell, checking for $ADB_TRACE will be better.